### PR TITLE
Include back section title as back button + light status bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
 xcuserdata
+Package.resolved
 Fastlane/report.xml
 Fastlane/README.md

--- a/LICENSE
+++ b/LICENSE
@@ -44,3 +44,13 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+## [SwiftUI-Introspect](https://github.com/siteline/SwiftUI-Introspect/blob/master/LICENSE)
+
+Copyright 2019 Timber Software
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Movapp--iOS--Info.plist
+++ b/Movapp--iOS--Info.plist
@@ -3,6 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleDefault</string>
+	<string>UIStatusBarStyleLightContent</string>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/Movapp.xcodeproj/project.pbxproj
+++ b/Movapp.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		B03B1BCA28186F7A005C62C3 /* SpeakButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03B1BC928186F7A005C62C3 /* SpeakButtonView.swift */; };
 		B03B1BCC28186F8D005C62C3 /* SoundStateButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03B1BCB28186F8D005C62C3 /* SoundStateButtonView.swift */; };
 		B03B1BD1281889CF005C62C3 /* LanguageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03B1BD0281889CF005C62C3 /* LanguageService.swift */; };
+		B03B1BCF28187F51005C62C3 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = B03B1BCE28187F51005C62C3 /* Introspect */; };
 		B05FF14327FA14A00046D636 /* SoundService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05FF14227FA14A00046D636 /* SoundService.swift */; };
 		B066546C27FB7D3C002D5EDD /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = B066546B27FB7D3C002D5EDD /* Language.swift */; };
 		B066546E27FB7E0C002D5EDD /* SetLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B066546D27FB7E0C002D5EDD /* SetLanguage.swift */; };
@@ -195,6 +196,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B03B1BCF28187F51005C62C3 /* Introspect in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -518,6 +520,9 @@
 				444E97142812DF8F00DC6F8B /* PBXTargetDependency */,
 			);
 			name = "Movapp (iOS)";
+			packageProductDependencies = (
+				B03B1BCE28187F51005C62C3 /* Introspect */,
+			);
 			productName = "Movapp (iOS)";
 			productReference = B012799C27F86957003FB72E /* Movapp.app */;
 			productType = "com.apple.product-type.application";
@@ -554,6 +559,9 @@
 				Base,
 			);
 			mainGroup = B012798F27F86954003FB72E;
+			packageReferences = (
+				B03B1BCD28187F51005C62C3 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
+			);
 			productRefGroup = B012799D27F86957003FB72E /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1039,6 +1047,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		B03B1BCD28187F51005C62C3 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
+			requirement = {
+				kind = exactVersion;
+				version = 0.1.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B03B1BCE28187F51005C62C3 /* Introspect */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B03B1BCD28187F51005C62C3 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
+			productName = Introspect;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = B012799027F86954003FB72E /* Project object */;
 }

--- a/Shared/Alphabet/AlphabetView.swift
+++ b/Shared/Alphabet/AlphabetView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-
+import Introspect
 
 struct AlphabetView: View {
     @EnvironmentObject var dataStore: AlphabetDataStore
@@ -21,6 +21,12 @@ struct AlphabetView: View {
             }
             .pickerStyle(.segmented)
             .padding()
+            .background(Color("colors/primary"))
+            .introspectSegmentedControl { control in
+                control.setTitleTextAttributes([.foregroundColor: UIColor(white: 1, alpha: 0.8)], for: .normal)
+                
+                control.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .selected)
+            }
             
             if let alphabet = dataStore.alphabet {
                 ScrollViewReader { proxy in

--- a/Shared/Dicitionary/AccordionHeaderView.swift
+++ b/Shared/Dicitionary/AccordionHeaderView.swift
@@ -17,11 +17,6 @@ struct AccordionHeaderView: View {
             if selectedSection != nil {
                 Image(systemName: "chevron.left")
                     .foregroundColor(Color("colors/secondary"))
-                    .onTapGesture {
-                        withAnimation(.spring()) {
-                            selectedSection = nil
-                        }
-                    }
                 
                 
                 let text = selectedSection!.text(language: language)
@@ -31,7 +26,13 @@ struct AccordionHeaderView: View {
                     .lineLimit(1)
                 Spacer()
             }
-        }.frame(maxWidth: .infinity)
+        }
+        .frame(maxWidth: .infinity)
+        .onTapGesture {
+            withAnimation(.spring()) {
+                selectedSection = nil
+            }
+        }
     }
 }
 

--- a/Shared/Dicitionary/DictionaryHeaderView.swift
+++ b/Shared/Dicitionary/DictionaryHeaderView.swift
@@ -50,5 +50,6 @@ struct DictionaryHeaderView: View {
 struct DictionaryHeaderView_Previews: PreviewProvider {
     static var previews: some View {
         DictionaryHeaderView(searchString: .constant("Test"))
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/Shared/Root/RootContentView.swift
+++ b/Shared/Root/RootContentView.swift
@@ -20,24 +20,49 @@ struct RootContentView: View {
     @EnvironmentObject var languageService: LanguageService
     
     var body: some View {
-        TabView {
-            DicitionaryView(selectedLanguage: languageService.currentLanguage)
-                .setTabItem(RootItems.dictionary)
+        ZStack(alignment: .top) {
             
-            AlphabetView()
-                .setTabItem(RootItems.alphabet)
+            TabView {
+                DicitionaryView(selectedLanguage: languageService.currentLanguage)
+                    .setTabItem(RootItems.dictionary)
+                
+                AlphabetView()
+                    .setTabItem(RootItems.alphabet)
+                
+                ForChildrenView()
+                    .setTabItem(RootItems.for_chidlren)
+                
+                MenuView(selectedLanguage: languageService.currentLanguage)
+                    .setTabItem(RootItems.menu)
+            }
             
-            ForChildrenView()
-                .setTabItem(RootItems.for_chidlren)
-            
-            MenuView(selectedLanguage: languageService.currentLanguage)
-                .setTabItem(RootItems.menu)
+            // Add background under the status bar to ensure that status bar can be .lightContent
+            // https://designcode.io/swiftui-handbook-status-bar-background-on-scroll
+            Rectangle()
+                .foregroundColor(Color("colors/primary"))
+                .ignoresSafeArea()
+                .frame(height: 0)
         }
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
+    static let soundService = SoundService()
+    static let favoritesService = TranslationFavoritesService()
+    static let favoritesProvider = TranslationFavoritesProvider(favoritesService: favoritesService)
+    static let dictionaryDataStore = DictionaryDataStore()
+    static let alphabetDataStore = AlphabetDataStore()
+    static let forKidsDataStore = ForChildrenDataStore()
+    static let languageService = LanguageService(dictionaryDataStore: dictionaryDataStore)
+    
     static var previews: some View {
         RootContentView()
+            .environmentObject(soundService)
+            .environmentObject(favoritesService)
+            .environmentObject(favoritesProvider)
+            .environmentObject(dictionaryDataStore)
+            .environmentObject(alphabetDataStore)
+            .environmentObject(forKidsDataStore)
+            .environmentObject(languageService)
     }
 }


### PR DESCRIPTION
#41 a #42


@petrillek přepínání barvy baterky atd by bylo docela náročné udělat (co jsem našel). Sjednotil jsem spíše tedy pozadí pod status barem (chová se to pak lépe se skrečování). Abecedu jsem upravil aby využila nový prostor a trochu změnil barvy přepínána.
![Simulator Screen Shot - iPhone 13 - 2022-04-26 at 21 35 57](https://user-images.githubusercontent.com/1878831/165378901-4e0749bd-2bfa-4540-bf78-3616aeebaf2d.png)
![Simulator Screen Shot - iPhone 13 - 2022-04-26 at 21 36 10](https://user-images.githubusercontent.com/1878831/165378905-301b2c6c-b1a7-4248-adf2-22c97063e3dc.png)

![Simulator Screen Shot - iPhone 13 - 2022-04-26 at 21 36 04](https://user-images.githubusercontent.com/1878831/165378891-6eab4c7e-618f-4d0b-8c0e-e04066e233de.png)

