### PR TITLE
Lepší verzovací schéma

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,21 +2,17 @@
 
 - [Správa slovíček](translations/README.md)
 
-# Git
+## Git
 
 - Používejte rebase politiku (vždy vycházejte z `main`)
 - Před mergem vždy rebasnete nad `main` a vyřešíte konflitky
 - Pro vložení do `main` se provede squash commit a nebo si lokálně upravte komity
 
-# Verzování
-
-Používáme schéme `x.y.z`, kde změny `z` znamenají pouze interní releasy, například nové testovací verze pro interní tým, `y` se zvedá při posílání nové verze do App Storu a `x` si necháváme v záloze pro zásadnější změny.
-
-# Fastlane
+## Fastlane
 
 Pro automatizaci releasů a souvisejících procesů používáme [Fastlane](https://fastlane.tools). Samotnou Fastlane můžete nainstalovat buď přes `brew install fastlane`, nebo lépe přímo v repository příkazem `bundle`. Ta lokální instalace v repu je lepší v tom, že všichni používáme stejnou verzi. Dál počítáme s tím, že jste Fastlane nainstalovali takhle. Pokud ne, pište místo `bundle exec fastlane` prostě jen `fastlane`.
 
-# Podepisování
+## Podepisování
 
 Pro podepsání kódu jsou potřeba certifikáty a profily, které se dají stáhnout přes Fastlane:
 
@@ -24,21 +20,25 @@ Pro podepsání kódu jsou potřeba certifikáty a profily, které se dají stá
 bundle exec fastlane match development --readonly
 ```
 
-# Releasing
+## Releasing
 
-Během vývoje přidávejte informace o novinkách do souboru `CHANGELOG.md` do sekce `[Unreleased]`. Pokud v ní před releasem ještě něco chybí, doplňte a commitněte. Pak vyrobíte nový release přes Fastlane:
+Během vývoje přidávejte informace o novinkách do souboru `CHANGELOG.md` do sekce `[Unreleased]`. Pokud v ní před releasem ještě něco chybí, doplňte a commitněte.
 
-```
-bundle exec fastlane release # 1.2.1 → 1.2.2
-```
-
-Tohle standardně vyrobí „patch release“, tedy zvedne poslední číslo verze. Pokud chcete zvýšit prostředí číslo verze, vypadá to takhle:
+Pak vyrobíte nový release přes Fastlane:
 
 ```
-bundle exec fastlane release type:minor # 1.2.1 → 1.3.0
+bundle exec fastlane release
 ```
 
-Fastlane zvýší číslo verze všude, kde je potřeba, aktualizuje changelog a vyrobí nový tag v Gitu.
+Tohle zvýší číslo buildu, aktualizuje changelog, commitne všechno do repa a otaguje release.
+
+Pokud chcete zvýšit marketingové číslo verze, dělá se to takhle:
+
+```
+bundle exec fastlane bump_version
+```
+
+Fastlane zvýší číslo verze všude, kde je potřeba, a commitne.
 
 ## Assets
 

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -1,11 +1,8 @@
-desc "Make a new release: Bump version number, update changelog and commit & tag the changes"
+desc "Make a new release: Bump build number, update changelog and commit & tag the changes"
 lane :release do |options|
 
     # Make sure we don't commit any work-in-progress with the release
     ensure_git_status_clean
-
-    # Read the release type from command-line arguments, default to patch
-    release_type = options[:type] ? options[:type] : "patch"
 
     # Bump version number
     increment_version_number_in_xcodeproj(bump_type: release_type, target: "Movapp (iOS)")
@@ -25,6 +22,28 @@ lane :release do |options|
         xcodeproj: "Movapp.xcodeproj",
         force: true)
     add_git_tag(tag: "v#{version_number}")
+end
+
+desc "Bump marketing version"
+lane :bump_version do |options|
+
+    # Make sure we don't commit any work-in-progress with the release
+    ensure_git_status_clean
+
+    # Read the release type from command-line arguments, default to patch
+    component = options[:type] ? options[:type] : "minor"
+
+    # Bump version number
+    increment_version_number_in_xcodeproj(bump_type: component, target: "Movapp (iOS)")
+    increment_version_number_in_xcodeproj(bump_type: component, target: "WatchMovapp")
+    increment_version_number_in_xcodeproj(bump_type: component, target: "WatchMovapp WatchKit Extension")
+    version_number = get_version_number(target: "Movapp (iOS)")
+
+    # Commit changes
+    commit_version_bump(
+        message: "Bump marketing version to #{version_number}",
+        xcodeproj: "Movapp.xcodeproj",
+        force: true)
 end
 
 # Create a clean temporary keychain

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -4,24 +4,23 @@ lane :release do |options|
     # Make sure we don't commit any work-in-progress with the release
     ensure_git_status_clean
 
-    # Bump version number
-    increment_version_number_in_xcodeproj(bump_type: release_type, target: "Movapp (iOS)")
-    increment_version_number_in_xcodeproj(bump_type: release_type, target: "WatchMovapp")
-    increment_version_number_in_xcodeproj(bump_type: release_type, target: "WatchMovapp WatchKit Extension")
+    # Bump build number
+    increment_build_number()
     version_number = get_version_number(target: "Movapp (iOS)")
+    build_number = get_build_number()
 
     # Update changelog with the version number and release date
-    stamp_changelog(section_identifier: version_number)
+    stamp_changelog(section_identifier: "#{version_number}, build #{build_number}")
 
     # Commit the stamped changelog as a part of the release
     git_add(path: 'CHANGELOG.md')
 
     # Commit and tag the release
     commit_version_bump(
-        message: "Release #{version_number}",
+        message: "Release #{version_number}, build #{build_number}",
         xcodeproj: "Movapp.xcodeproj",
         force: true)
-    add_git_tag(tag: "v#{version_number}")
+    add_git_tag(tag: "v#{version_number}-#{build_number}")
 end
 
 desc "Bump marketing version"

--- a/Movapp.xcodeproj/project.pbxproj
+++ b/Movapp.xcodeproj/project.pbxproj
@@ -717,7 +717,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = WatchMovapp;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = cz.movapp.app;
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = cz.movapp.app.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development cz.movapp.app.watchkitapp";
@@ -744,7 +744,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = WatchMovapp;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = cz.movapp.app;
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = cz.movapp.app.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore cz.movapp.app.watchkitapp";
@@ -777,7 +777,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = cz.movapp.app.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development cz.movapp.app.watchkitapp.watchkitextension";
@@ -809,7 +809,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = cz.movapp.app.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore cz.movapp.app.watchkitapp.watchkitextension";
@@ -962,7 +962,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = cz.movapp.app;
 				PRODUCT_NAME = Movapp;
 				PROVISIONING_PROFILE_SPECIFIER = "match Development cz.movapp.app";
@@ -995,7 +995,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = cz.movapp.app;
 				PRODUCT_NAME = Movapp;
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore cz.movapp.app";


### PR DESCRIPTION
Fixes #54. Změnil jsem Fastlane akci `release` tak, aby místo marketingového čísla verze měnila číslo buildu, a pro zvýšení marketingové verze jsem přidal akci `bump_version`. Takže akce `release` se používá při běžném vývoji a `bump_version` jednou za čas, když vydáme novou verzi do App Storu. Akorát verzovací schéma jsem nechal na `major.minor.patch`, protože to tak Fastlane dělá automaticky.

PS. A zrovna jsem udělal marketing bump na 1.1.