### PR TITLE
Add scheme with UI tests + screenshots + add fastlane screenshots generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 xcuserdata
 Package.resolved
 Fastlane/report.xml
+Fastlane/screenshots
 Fastlane/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 
 Pro automatizaci releasů a souvisejících procesů používáme [Fastlane](https://fastlane.tools). Samotnou Fastlane můžete nainstalovat buď přes `brew install fastlane`, nebo lépe přímo v repository příkazem `bundle`. Ta lokální instalace v repu je lepší v tom, že všichni používáme stejnou verzi. Dál počítáme s tím, že jste Fastlane nainstalovali takhle. Pokud ne, pište místo `bundle exec fastlane` prostě jen `fastlane`.
 
-## Podepisování
+### Podepisování
 
 Pro podepsání kódu jsou potřeba certifikáty a profily, které se dají stáhnout přes Fastlane:
 
@@ -20,7 +20,7 @@ Pro podepsání kódu jsou potřeba certifikáty a profily, které se dají stá
 bundle exec fastlane match development --readonly
 ```
 
-## Releasing
+### Releasing
 
 Během vývoje přidávejte informace o novinkách do souboru `CHANGELOG.md` do sekce `[Unreleased]`. Pokud v ní před releasem ještě něco chybí, doplňte a commitněte.
 
@@ -39,6 +39,13 @@ bundle exec fastlane bump_version
 ```
 
 Fastlane zvýší číslo verze všude, kde je potřeba, a commitne.
+
+### Generováná screenshotů
+
+- `bundle exec fastlane snapshot` - vygeneruje screenshoty
+- Screenshoty jsou v fastlane/screenshots
+- Po vygenerování se udělá i pěkný "view" na screenshoty fastlane/screenshots/screenshots.html
+
 
 ## Assets
 

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -60,7 +60,7 @@ lane :build do
     # This makes sure all code signing runs with a temporary, unlocked keychain
     ensure_temp_keychain 'fastlane'
     sync_code_signing(type: "development", readonly: true, keychain_password: "temppassword", keychain_name: "fastlane")
-    build_app(skip_archive: true, configuration: "Debug")
+    build_app(skip_archive: true, configuration: "Debug", scheme: "Movapp (iOS)")
 end
 
 lane :upload do
@@ -74,8 +74,8 @@ lane :upload do
     # This makes sure all code signing runs with a temporary, unlocked keychain
     ensure_temp_keychain 'fastlane'
     sync_code_signing(type: "appstore", readonly: true, keychain_password: "temppassword", keychain_name: "fastlane")
-    build_app(configuration: "Release")
     capture_screenshots
+    build_app(configuration: "Release", scheme: "Movapp (iOS)")
     upload_to_app_store(
         username: "apple-code-signing@cesko.digital",
         team_id: "8495ZSK6A6",

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -75,6 +75,7 @@ lane :upload do
     ensure_temp_keychain 'fastlane'
     sync_code_signing(type: "appstore", readonly: true, keychain_password: "temppassword", keychain_name: "fastlane")
     build_app(configuration: "Release")
+    capture_screenshots
     upload_to_app_store(
         username: "apple-code-signing@cesko.digital",
         team_id: "8495ZSK6A6",
@@ -82,6 +83,10 @@ lane :upload do
         precheck_include_in_app_purchases: false,
         force: true,
         skip_metadata: true,
-        skip_screenshots: true
+        skip_screenshots: false
     )
+end
+
+lane :tests do
+  run_tests(scheme: "MovappUITests")
 end

--- a/Fastlane/Snapfile
+++ b/Fastlane/Snapfile
@@ -1,0 +1,31 @@
+# Uncomment the lines below you want to change by removing the # in the beginning
+
+# A list of devices you want to take the screenshots from
+devices([
+  "iPhone 11 Pro Max",
+  "iPhone 8 Plus"
+])
+
+languages([
+   "en-UK",
+   "cs-CZ",
+   "uk",
+ ])
+
+# The name of the scheme which contains the UI Tests
+scheme("MovappScreenshots")
+
+# Where should the resulting screenshots be stored?
+output_directory("./fastlane/screenshots")
+
+# remove the '#' to clear all previously generated screenshots before creating new ones
+clear_previous_screenshots(true)
+
+# Remove the '#' to set the status bar to 9:41 AM, and show full battery and reception. See also override_status_bar_arguments for custom options.
+# override_status_bar(true)
+
+# Arguments to pass to the app on launch. See https://docs.fastlane.tools/actions/snapshot/#launch-arguments
+# launch_arguments(["-favColor red"])
+
+# For more information about all available options run
+# fastlane action snapshot

--- a/Fastlane/SnapshotHelper.swift
+++ b/Fastlane/SnapshotHelper.swift
@@ -1,0 +1,309 @@
+//
+//  SnapshotHelper.swift
+//  Example
+//
+//  Created by Felix Krause on 10/8/15.
+//
+
+// -----------------------------------------------------
+// IMPORTANT: When modifying this file, make sure to
+//            increment the version number at the very
+//            bottom of the file to notify users about
+//            the new SnapshotHelper.swift
+// -----------------------------------------------------
+
+import Foundation
+import XCTest
+
+var deviceLanguage = ""
+var locale = ""
+
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+    Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
+}
+
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+    if waitForLoadingIndicator {
+        Snapshot.snapshot(name)
+    } else {
+        Snapshot.snapshot(name, timeWaitingForIdle: 0)
+    }
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+    Snapshot.snapshot(name, timeWaitingForIdle: timeout)
+}
+
+enum SnapshotError: Error, CustomDebugStringConvertible {
+    case cannotFindSimulatorHomeDirectory
+    case cannotRunOnPhysicalDevice
+
+    var debugDescription: String {
+        switch self {
+        case .cannotFindSimulatorHomeDirectory:
+            return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+        case .cannotRunOnPhysicalDevice:
+            return "Can't use Snapshot on a physical device."
+        }
+    }
+}
+
+@objcMembers
+open class Snapshot: NSObject {
+    static var app: XCUIApplication?
+    static var waitForAnimations = true
+    static var cacheDirectory: URL?
+    static var screenshotsDirectory: URL? {
+        return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
+    }
+
+    open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+
+        Snapshot.app = app
+        Snapshot.waitForAnimations = waitForAnimations
+
+        do {
+            let cacheDir = try getCacheDirectory()
+            Snapshot.cacheDirectory = cacheDir
+            setLanguage(app)
+            setLocale(app)
+            setLaunchArguments(app)
+        } catch let error {
+            NSLog(error.localizedDescription)
+        }
+    }
+
+    class func setLanguage(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("language.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+            app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
+        } catch {
+            NSLog("Couldn't detect/set language...")
+        }
+    }
+
+    class func setLocale(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("locale.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            locale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+        } catch {
+            NSLog("Couldn't detect/set locale...")
+        }
+
+        if locale.isEmpty && !deviceLanguage.isEmpty {
+            locale = Locale(identifier: deviceLanguage).identifier
+        }
+
+        if !locale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+        }
+    }
+
+    class func setLaunchArguments(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
+
+        do {
+            let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
+            let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count))
+            let results = matches.map { result -> String in
+                (launchArguments as NSString).substring(with: result.range)
+            }
+            app.launchArguments += results
+        } catch {
+            NSLog("Couldn't detect/set launch_arguments...")
+        }
+    }
+
+    open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+        if timeout > 0 {
+            waitForLoadingIndicatorToDisappear(within: timeout)
+        }
+
+        NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
+
+        if Snapshot.waitForAnimations {
+            sleep(1) // Waiting for the animation to be finished (kind of)
+        }
+
+        #if os(OSX)
+            guard let app = self.app else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+        #else
+
+            guard self.app != nil else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            let screenshot = XCUIScreen.main.screenshot()
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+            #else
+            let image = screenshot.image
+            #endif
+
+            guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
+
+            do {
+                // The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
+                let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
+                let range = NSRange(location: 0, length: simulator.count)
+                simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
+
+                let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
+                #if swift(<5.0)
+                    UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                #else
+                    try image.pngData()?.write(to: path, options: .atomic)
+                #endif
+            } catch let error {
+                NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
+                NSLog(error.localizedDescription)
+            }
+        #endif
+    }
+
+    class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+        #if os(watchOS)
+            return image
+        #else
+            if #available(iOS 10.0, *) {
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = image.scale
+                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+                return renderer.image { context in
+                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+                }
+            } else {
+                return image
+            }
+        #endif
+    }
+
+    class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
+        #if os(tvOS)
+            return
+        #endif
+
+        guard let app = self.app else {
+            NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            return
+        }
+
+        let networkLoadingIndicator = app.otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+        _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
+    }
+
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
+        // on OSX config is stored in /Users/<username>/Library
+        // and on iOS/tvOS/WatchOS it's in simulator's home dir
+        #if os(OSX)
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64) || arch(arm64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
+            }
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
+        #else
+            throw SnapshotError.cannotRunOnPhysicalDevice
+        #endif
+    }
+}
+
+private extension XCUIElementAttributes {
+    var isNetworkLoadingIndicator: Bool {
+        if hasAllowListedIdentifier { return false }
+
+        let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+        let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+        return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+    }
+
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+
+        return allowListedIdentifiers.contains(identifier)
+    }
+
+    func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+        if elementType == .statusBar { return true }
+        guard frame.origin == .zero else { return false }
+
+        let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+        let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+        return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+    }
+}
+
+private extension XCUIElementQuery {
+    var networkLoadingIndicators: XCUIElementQuery {
+        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isNetworkLoadingIndicator
+        }
+
+        return self.containing(isNetworkLoadingIndicator)
+    }
+
+    var deviceStatusBars: XCUIElementQuery {
+        guard let app = Snapshot.app else {
+            fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+        }
+
+        let deviceWidth = app.windows.firstMatch.frame.width
+
+        let isStatusBar = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isStatusBar(deviceWidth)
+        }
+
+        return self.containing(isStatusBar)
+    }
+}
+
+private extension CGFloat {
+    func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+        return numberA...numberB ~= self
+    }
+}
+
+// Please don't remove the lines below
+// They are used to detect outdated configuration files
+// SnapshotHelperVersion [1.28]

--- a/Movapp.xcodeproj/project.pbxproj
+++ b/Movapp.xcodeproj/project.pbxproj
@@ -44,6 +44,11 @@
 		B08B0DF5281FD0F2000EAEF1 /* Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08B0DF4281FD0F2000EAEF1 /* Team.swift */; };
 		B08B0DF7281FD1D8000EAEF1 /* TeamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08B0DF6281FD1D8000EAEF1 /* TeamView.swift */; };
 		B08B0DF9281FD49B000EAEF1 /* TeamDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08B0DF8281FD49B000EAEF1 /* TeamDataStore.swift */; };
+		B08B0DE5281FBB28000EAEF1 /* MovappUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08B0DE4281FBB28000EAEF1 /* MovappUITests.swift */; };
+		B08B0DE7281FBB28000EAEF1 /* MovappUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08B0DE6281FBB28000EAEF1 /* MovappUITestsLaunchTests.swift */; };
+		B08B0DEE281FBBFC000EAEF1 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08B0DED281FBBFC000EAEF1 /* SnapshotHelper.swift */; };
+		B08B0DF0281FBF5B000EAEF1 /* FastlaneSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08B0DEF281FBF5B000EAEF1 /* FastlaneSnapshot.swift */; };
+		B08B0DF1281FC161000EAEF1 /* RootItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01279C527F870BF003FB72E /* RootItems.swift */; };
 		B0C0F8E528060A310036441E /* ForChildrenRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C0F8E428060A310036441E /* ForChildrenRowView.swift */; };
 		B0C0F8E828060B750036441E /* Flags.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C0F8E728060B750036441E /* Flags.swift */; };
 		B0C9F40A27FCBF5500B075EB /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B0C9F40927FCBF5500B075EB /* Launch Screen.storyboard */; };
@@ -59,6 +64,16 @@
 		B0ECC14C2803431A00BF9898 /* Bundle+version.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ECC14B2803431A00BF9898 /* Bundle+version.swift */; };
 		B0ECC1502803485B00BF9898 /* AlphabetShortcutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ECC14F2803485B00BF9898 /* AlphabetShortcutsView.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B08B0DE8281FBB28000EAEF1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B012799027F86954003FB72E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B012799B27F86957003FB72E;
+			remoteInfo = "Movapp (iOS)";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		444E97162812DF8F00DC6F8B /* Embed Watch Content */ = {
@@ -127,6 +142,11 @@
 		B08B0DF4281FD0F2000EAEF1 /* Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Team.swift; sourceTree = "<group>"; };
 		B08B0DF6281FD1D8000EAEF1 /* TeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamView.swift; sourceTree = "<group>"; };
 		B08B0DF8281FD49B000EAEF1 /* TeamDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamDataStore.swift; sourceTree = "<group>"; };
+		B08B0DE2281FBB28000EAEF1 /* MovappUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MovappUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B08B0DE4281FBB28000EAEF1 /* MovappUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovappUITests.swift; sourceTree = "<group>"; };
+		B08B0DE6281FBB28000EAEF1 /* MovappUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovappUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		B08B0DED281FBBFC000EAEF1 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotHelper.swift; path = Fastlane/SnapshotHelper.swift; sourceTree = SOURCE_ROOT; };
+		B08B0DEF281FBF5B000EAEF1 /* FastlaneSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastlaneSnapshot.swift; sourceTree = "<group>"; };
 		B0C0F8E428060A310036441E /* ForChildrenRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForChildrenRowView.swift; sourceTree = "<group>"; };
 		B0C0F8E728060B750036441E /* Flags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flags.swift; sourceTree = "<group>"; };
 		B0C0F8E928060BE60036441E /* Languages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Languages.swift; sourceTree = "<group>"; };
@@ -155,6 +175,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				B03B1BCF28187F51005C62C3 /* Introspect in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B08B0DDF281FBB28000EAEF1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -252,6 +279,7 @@
 				B01279A327F86957003FB72E /* macOS */,
 				444E96FB2812DF8C00DC6F8B /* WatchMovapp */,
 				444E97062812DF8E00DC6F8B /* WatchMovapp WatchKit Extension */,
+				B08B0DE3281FBB28000EAEF1 /* MovappUITests */,
 				B012799D27F86957003FB72E /* Products */,
 				B01279E027F88504003FB72E /* Frameworks */,
 			);
@@ -283,6 +311,7 @@
 			isa = PBXGroup;
 			children = (
 				B012799C27F86957003FB72E /* Movapp.app */,
+				B08B0DE2281FBB28000EAEF1 /* MovappUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -411,6 +440,17 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		B08B0DE3281FBB28000EAEF1 /* MovappUITests */ = {
+			isa = PBXGroup;
+			children = (
+				B08B0DED281FBBFC000EAEF1 /* SnapshotHelper.swift */,
+				B08B0DE4281FBB28000EAEF1 /* MovappUITests.swift */,
+				B08B0DEF281FBF5B000EAEF1 /* FastlaneSnapshot.swift */,
+				B08B0DE6281FBB28000EAEF1 /* MovappUITestsLaunchTests.swift */,
+			);
+			path = MovappUITests;
+			sourceTree = "<group>";
+		};
 		B0C0F8E628060B6C0036441E /* Enums */ = {
 			isa = PBXGroup;
 			children = (
@@ -453,6 +493,24 @@
 			productReference = B012799C27F86957003FB72E /* Movapp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		B08B0DE1281FBB28000EAEF1 /* MovappUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B08B0DEC281FBB28000EAEF1 /* Build configuration list for PBXNativeTarget "MovappUITests" */;
+			buildPhases = (
+				B08B0DDE281FBB28000EAEF1 /* Sources */,
+				B08B0DDF281FBB28000EAEF1 /* Frameworks */,
+				B08B0DE0281FBB28000EAEF1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B08B0DE9281FBB28000EAEF1 /* PBXTargetDependency */,
+			);
+			name = MovappUITests;
+			productName = MovappUITests;
+			productReference = B08B0DE2281FBB28000EAEF1 /* MovappUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -460,11 +518,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
+				LastSwiftUpdateCheck = 1330;
 				LastUpgradeCheck = 1330;
 				TargetAttributes = {
 					B012799B27F86957003FB72E = {
 						CreatedOnToolsVersion = 13.3;
+					};
+					B08B0DE1281FBB28000EAEF1 = {
+						CreatedOnToolsVersion = 13.3.1;
+						TestTargetID = B012799B27F86957003FB72E;
 					};
 				};
 			};
@@ -487,6 +549,7 @@
 			projectRoot = "";
 			targets = (
 				B012799B27F86957003FB72E /* Movapp (iOS) */,
+				B08B0DE1281FBB28000EAEF1 /* MovappUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -499,6 +562,13 @@
 				B0C9F40A27FCBF5500B075EB /* Launch Screen.storyboard in Resources */,
 				B01279A927F86957003FB72E /* Assets.xcassets in Resources */,
 				B087C88927F8A3BD0015E54B /* Localizable.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B08B0DE0281FBB28000EAEF1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -559,7 +629,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B08B0DDE281FBB28000EAEF1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B08B0DE5281FBB28000EAEF1 /* MovappUITests.swift in Sources */,
+				B08B0DE7281FBB28000EAEF1 /* MovappUITestsLaunchTests.swift in Sources */,
+				B08B0DF1281FC161000EAEF1 /* RootItems.swift in Sources */,
+				B08B0DEE281FBBFC000EAEF1 /* SnapshotHelper.swift in Sources */,
+				B08B0DF0281FBF5B000EAEF1 /* FastlaneSnapshot.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B08B0DE9281FBB28000EAEF1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B012799B27F86957003FB72E /* Movapp (iOS) */;
+			targetProxy = B08B0DE8281FBB28000EAEF1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		B087C88727F8A3BD0015E54B /* Localizable.strings */ = {
@@ -768,6 +858,49 @@
 			};
 			name = Release;
 		};
+		B08B0DEA281FBB28000EAEF1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8495ZSK6A6;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = cz.movapp.MovappUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Movapp (iOS)";
+			};
+			name = Debug;
+		};
+		B08B0DEB281FBB28000EAEF1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8495ZSK6A6;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = cz.movapp.MovappUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Movapp (iOS)";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -785,6 +918,15 @@
 			buildConfigurations = (
 				B01279AE27F86957003FB72E /* Debug */,
 				B01279AF27F86957003FB72E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B08B0DEC281FBB28000EAEF1 /* Build configuration list for PBXNativeTarget "MovappUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B08B0DEA281FBB28000EAEF1 /* Debug */,
+				B08B0DEB281FBB28000EAEF1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Movapp.xcodeproj/xcshareddata/xcschemes/MovappScreenshots.xcscheme
+++ b/Movapp.xcodeproj/xcshareddata/xcschemes/MovappScreenshots.xcscheme
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B012799B27F86957003FB72E"
-               BuildableName = "Movapp.app"
-               BlueprintName = "Movapp (iOS)"
+               BlueprintIdentifier = "B08B0DE1281FBB28000EAEF1"
+               BuildableName = "MovappUITests.xctest"
+               BlueprintName = "MovappUITests"
                ReferencedContainer = "container:Movapp.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -37,6 +37,14 @@
                BlueprintName = "MovappUITests"
                ReferencedContainer = "container:Movapp.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "MovappUITests">
+               </Test>
+               <Test
+                  Identifier = "MovappUITestsLaunchTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>
@@ -44,7 +52,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      region = "UA"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -68,16 +75,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B012799B27F86957003FB72E"
-            BuildableName = "Movapp.app"
-            BlueprintName = "Movapp (iOS)"
-            ReferencedContainer = "container:Movapp.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Movapp.xcodeproj/xcshareddata/xcschemes/MovappUITests.xcscheme
+++ b/Movapp.xcodeproj/xcshareddata/xcschemes/MovappUITests.xcscheme
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B012799B27F86957003FB72E"
-               BuildableName = "Movapp.app"
-               BlueprintName = "Movapp (iOS)"
+               BlueprintIdentifier = "B08B0DE1281FBB28000EAEF1"
+               BuildableName = "MovappUITests.xctest"
+               BlueprintName = "MovappUITests"
                ReferencedContainer = "container:Movapp.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -37,6 +37,11 @@
                BlueprintName = "MovappUITests"
                ReferencedContainer = "container:Movapp.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "FastlaneSnapshot">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>
@@ -44,7 +49,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      region = "UA"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -68,16 +72,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B012799B27F86957003FB72E"
-            BuildableName = "Movapp.app"
-            BlueprintName = "Movapp (iOS)"
-            ReferencedContainer = "container:Movapp.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/MovappUITests/FastlaneSnapshot.swift
+++ b/MovappUITests/FastlaneSnapshot.swift
@@ -1,0 +1,63 @@
+//
+//  FastlaneSnapshot.swift
+//  MovappUITests
+//
+//  Created by Martin Kluska on 02.05.2022.
+//
+
+import XCTest
+
+class FastlaneSnapshot: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        setupSnapshot(app)
+        app.launch()
+        
+        
+        snapshot("1 - Dictionary")
+
+        
+        app.scrollViews.otherElements/*@START_MENU_TOKEN@*/.staticTexts["dictionary_0"]/*[[".staticTexts[\"Základní fráze - Основні фрази\"]",".staticTexts[\"dictionary_0\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        
+        snapshot("1 - Dictionary detail")
+        
+        
+        app.tabBars.buttons.element(boundBy: 1).tap()
+        
+        snapshot("2 - Alphabet")
+        
+        
+        app.tabBars.buttons.element(boundBy: 2).tap()
+        
+        snapshot("3 - For Children")
+        
+        app.tabBars.buttons.element(boundBy: 3).tap()
+        
+        snapshot("4 - Menu")
+        
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/MovappUITests/MovappUITests.swift
+++ b/MovappUITests/MovappUITests.swift
@@ -1,0 +1,51 @@
+//
+//  MovappUITests.swift
+//  MovappUITests
+//
+//  Created by Martin Kluska on 02.05.2022.
+//
+
+import XCTest
+
+class MovappUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        
+        app.tabBars.buttons.element(boundBy: 0).tap()
+        
+        app.scrollViews.otherElements/*@START_MENU_TOKEN@*/.staticTexts["dictionary_0"]/*[[".staticTexts[\"Základní fráze - Основні фрази\"]",".staticTexts[\"dictionary_0\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        
+        
+        app.tabBars.buttons.element(boundBy: 1).tap()
+        app.tabBars.buttons.element(boundBy: 2).tap()
+        app.tabBars.buttons.element(boundBy: 3).tap()
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/MovappUITests/MovappUITestsLaunchTests.swift
+++ b/MovappUITests/MovappUITestsLaunchTests.swift
@@ -1,0 +1,34 @@
+//
+//  MovappUITestsLaunchTests.swift
+//  MovappUITests
+//
+//  Created by Martin Kluska on 02.05.2022.
+//
+
+import XCTest
+
+class MovappUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        
+                
+    }
+}

--- a/Shared/Dicitionary/AccordionsView.swift
+++ b/Shared/Dicitionary/AccordionsView.swift
@@ -22,6 +22,7 @@ struct AccordionsView: View {
                     let text = section.text(language: language)
                     
                     AccordionView(isOdd: isOdd, text:  text)
+                        .accessibilityIdentifier("dictionary_\(index)")
                         .onTapGesture {
                             withAnimation(.spring()) {
                                 selectedSection = section

--- a/Shared/Root/RootContentView.swift
+++ b/Shared/Root/RootContentView.swift
@@ -30,7 +30,7 @@ struct RootContentView: View {
                     .setTabItem(RootItems.alphabet)
                 
                 ForChildrenView(selectedLanguage: languageService.currentLanguage)
-                    .setTabItem(RootItems.for_chidlren)
+                    .setTabItem(RootItems.for_children)
                 
                 MenuView(selectedLanguage: languageService.currentLanguage)
                     .setTabItem(RootItems.menu)

--- a/Shared/Root/RootItems.swift
+++ b/Shared/Root/RootItems.swift
@@ -13,14 +13,14 @@ enum RootItems: Int, Hashable {
     
     case dictionary = 0
     case alphabet
-    case for_chidlren
+    case for_children
     case menu
     
     var icon: String {
         switch self {
         case .dictionary: return "icons/dictionary"
         case .alphabet: return "icons/alphabet"
-        case .for_chidlren: return "icons/child"
+        case .for_children: return "icons/child"
         case .menu: return "icons/menu"
         }
     }
@@ -29,7 +29,7 @@ enum RootItems: Int, Hashable {
         switch self {
         case .dictionary: return String(localized: "Dictionary", comment: "TabBar dictionary")
         case .alphabet: return String(localized: "Alphabet", comment: "TabBar aklphabet - use shortcut A-Z")
-        case .for_chidlren: return String(localized: "For Kids", comment: "TabBar For kids")
+        case .for_children: return String(localized: "For Kids", comment: "TabBar For kids")
         case .menu: return String(localized: "Menu", comment: "TabBar Menu")
         }
     }


### PR DESCRIPTION
- Přidal jsem generování screenshotů pro Appstore (i fastlane command) 
      - `bundle exec fastlane snapshot` - vygeneruje screenshoty
      - `bundle exec fastlane screenshots` - vygeneruje screenshoty a pošle do Appstore 
      - Screenshoty jsou v `fastlane/screenshots`
      - Po vygenerování se udělá i pěkný "view" na screenshoty `screenshots.html` -> toto možná někde publikovat?
- @zoul možná to budeš chtít pak přidat do actions pro deploy verze?
- Připravil jsem suite i pro UI tests, zatím to jenom proklikne tabbar - zatím bych klidně nepouštěl. `bundle exec fastlane tests`