### PR TITLE
Jednodušší proces pro vydávání releasů

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,9 @@ name: Deploy
 
 on:
   push:
-    branches: [release]
-  workflow_dispatch:
+    branches: [main]
+    tags:
+      - "v*"
 
 jobs:
   app_store:


### PR DESCRIPTION
Closes #74. Původně jsme releasy vyráběli z nových commitů ve větvi `release`, ale jelikož GitHub nedělá fast-forward merge, přijde nám to zbytečně zamotané, takže bychom zkusili vyrobit nový release z každého release tagu v `main`? Konkrétně tahle změna by měla zařídit, že se do App Storu nahraje nový build vždy po pushnutí nového tagu ve formátu `v…` do `main`.

Bavili jsme se taky o tom, že se nám na původním workflow s release PRs líbila ta možnost review. Říkal jsem, že u toho tag-based workflow tohle asi nepůjde, ale jde to, viz [Reviewing deployments](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments). Fungovalo by to tak, že by po pushnutí tagu naskočila deploy akce ve stavu _Waiting_ a vyžadovala by potvrzení od předem definovaných reviewers. Podle dosavadních zkušeností mně to zatím přijde spíš zbytečné, zkusil bych čistě to workflow založené na tags a uvidíme, jestli budou potřeba nějaké korekce?

Až tohle mergnem, můžem zahodit větev `release`.